### PR TITLE
Remove site-root parameter. This coupling isn't required.

### DIFF
--- a/src/SilverStripe/BlowGun/Command/ListenCommand.php
+++ b/src/SilverStripe/BlowGun/Command/ListenCommand.php
@@ -24,11 +24,6 @@ class ListenCommand extends BaseCommand {
 	/**
 	 * @var string
 	 */
-	protected $siteRoot = '';
-
-	/**
-	 * @var string
-	 */
 	protected $scriptDir = '';
 
 	/**
@@ -47,7 +42,6 @@ class ListenCommand extends BaseCommand {
 		$this->addArgument('cluster');
 		$this->addArgument('stack');
 		$this->addArgument('env');
-		$this->addOption('site-root', null, InputOption::VALUE_REQUIRED);
 		$this->addOption('script-dir', null, InputOption::VALUE_REQUIRED);
 		$this->addOption('node-name', null, InputOption::VALUE_REQUIRED);
 		// @todo(stig): add a verbose flag
@@ -64,7 +58,6 @@ class ListenCommand extends BaseCommand {
 		parent::execute($input, $output);
 
 		$this->queueService = new SQSHandler($this->profile, $this->region, $this->log);
-		$this->siteRoot = $this->getDirectoryFromInput($input, 'site-root');
 		$this->scriptDir = $this->getDirectoryFromInput($input, 'script-dir');
 		$this->nodeName = $input->getOption('node-name');
 
@@ -166,7 +159,7 @@ class ListenCommand extends BaseCommand {
 		}
 
 		$this->logNotice(sprintf('Running job %s', $message->getType()), $message);
-		$command = new Command($message, $this->scriptDir, $this->siteRoot);
+		$command = new Command($message, $this->scriptDir);
 		$status = $command->run();
 
 		foreach($status->getErrors() as $error) {

--- a/src/SilverStripe/BlowGun/Model/Command.php
+++ b/src/SilverStripe/BlowGun/Model/Command.php
@@ -24,12 +24,10 @@ class Command {
 	/**
 	 * @param Message $message
 	 * @param string $scriptDir
-	 * @param string $siteRoot
 	 */
-	public function __construct(Message $message, $scriptDir, $siteRoot) {
+	public function __construct(Message $message, $scriptDir) {
 		$this->message = $message;
 		$this->scriptDir = $scriptDir;
-		$this->siteRoot = $siteRoot;
 		$this->process = $this->getProcess();
 	}
 
@@ -67,7 +65,6 @@ class Command {
 				$builder->setEnv($name, $value);
 			}
 		}
-		$builder->setEnv('webroot', $this->siteRoot);
 		$process = $builder->getProcess();
 		$process->setTimeout(3600);
 		return $process;

--- a/src/SilverStripe/BlowGun/Tests/CommandTest.php
+++ b/src/SilverStripe/BlowGun/Tests/CommandTest.php
@@ -28,7 +28,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase {
 	public function testRunProcessIsSuccessful() {
 		$msg = new Message('test-queue', $this->handler);
 		$msg->setType('echo_command');
-		$command = new Command($msg, __DIR__ . '/test_scripts', 'siteroot');
+		$command = new Command($msg, __DIR__ . '/test_scripts');
 		$status = $command->run();
 		$this->assertTrue($status->isSuccessful());
 		$this->assertEquals('Hello world', $status->getNotices()[0]);
@@ -37,7 +37,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase {
 	public function testRunProcessScriptNotFound() {
 		$msg = new Message('test-queue', $this->handler);
 		$msg->setType('dont_exists');
-		$command = new Command($msg, __DIR__ . '/test_scripts', 'siteroot');
+		$command = new Command($msg, __DIR__ . '/test_scripts');
 		$status = $command->run();
 		$this->assertFalse($status->isSuccessful());
 		$this->assertContains('No such file', $status->getErrors()[0]);
@@ -46,7 +46,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase {
 	public function testRunProcessScriptError() {
 		$msg = new Message('test-queue', $this->handler);
 		$msg->setType('error_command');
-		$command = new Command($msg, __DIR__ . '/test_scripts', 'siteroot');
+		$command = new Command($msg, __DIR__ . '/test_scripts');
 		$status = $command->run();
 		$this->assertFalse($status->isSuccessful());
 		$this->assertEquals('I will fail', $status->getNotices()[0]);
@@ -58,7 +58,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase {
 		$msg->setType('arg_command');
 
 		$msg->setArgument('arg1', 'value1');
-		$command = new Command($msg, __DIR__ . '/test_scripts', 'siteroot');
+		$command = new Command($msg, __DIR__ . '/test_scripts');
 		$status = $command->run();
 		$this->assertTrue($status->isSuccessful());
 


### PR DESCRIPTION
Removing this gives us the ability to use blowgun in environments that
don't specifically have a website running in them. For example, you
might just want to run a remote command on a server.

Current scripts don't actually use the "webroot" parameter anyway, so we
won't really miss this site-root setting.
