### PR TITLE
Extend the visibility period to last until the next timeout.

### DIFF
--- a/src/SilverStripe/BlowGun/Model/Command.php
+++ b/src/SilverStripe/BlowGun/Model/Command.php
@@ -7,9 +7,9 @@ use Symfony\Component\Process\ProcessBuilder;
 class Command {
 
 	/**
-	 * SQS queues by default set message visibility to 30 seconds
+	 * SQS visibility period for updates
 	 */
-	const MSG_DEFAULT_VISIBILITY = 30;
+	const MSG_UPDATE_VISIBILITY_TIMEOUT = 30;
 
 	/**
 	 * @var Message
@@ -102,11 +102,14 @@ class Command {
 		// timeout so that the message doesn't get put back into the queue
 		// while this instance of the worker is still working on it.
 		$previousTime = time();
-		$timeout = (self::MSG_DEFAULT_VISIBILITY - 10);
+		$timeout = (self::MSG_UPDATE_VISIBILITY_TIMEOUT - 10);
 		while($this->process->isRunning()) {
 			$now = time();
 			if($previousTime + $timeout < $now) {
-				$this->message->increaseVisibility($timeout);
+				$this->message->increaseVisibility(self::MSG_UPDATE_VISIBILITY_TIMEOUT);
+				$this->message->logNotice(
+					sprintf('Increased visibility by %ss', self::MSG_UPDATE_VISIBILITY_TIMEOUT)
+				);
 				$previousTime = $now;
 			}
 			$this->process->checkTimeout();

--- a/src/SilverStripe/BlowGun/Model/Message.php
+++ b/src/SilverStripe/BlowGun/Model/Message.php
@@ -145,6 +145,22 @@ class Message {
 	}
 
 	/**
+	 * @param $errorMsg
+	 * @param Message $message
+	 */
+	public function logError($errorMsg) {
+		$this->handler->logError($errorMsg, $this);
+	}
+
+	/**
+	 * @param string $message
+	 *
+	 */
+	public function logNotice($errorMsg) {
+		$this->handler->logNotice($errorMsg, $this);
+	}
+
+	/**
 	 * @return string
 	 */
 	public function getQueue() {

--- a/src/SilverStripe/BlowGun/Service/SQSHandler.php
+++ b/src/SilverStripe/BlowGun/Service/SQSHandler.php
@@ -183,7 +183,7 @@ class SQSHandler {
 	}
 
 	/**
-	 * @param $errorMsg
+	 * @param string $errorMsg
 	 * @param Message $message
 	 */
 	public function logError($errorMsg, Message $message) {
@@ -191,11 +191,16 @@ class SQSHandler {
 	}
 
 	/**
-	 * @param string $message
+	 * @param string $errorMsg
+	 * @param Message $message
 	 *
 	 */
-	public function logNotice($message) {
-		$this->logger->notice($message, []);
+	public function logNotice($errorMsg, Message $message = null) {
+		if ($message) {
+			$this->logger->notice($errorMsg, [$message->getMessageId(), $message->getQueue()]);
+		} else {
+			$this->logger->notice($errorMsg, []);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Previously, with visibility period = timeout, there was a small chance
for the node to not manage to update the visibility in time, and the
essage to be picked by other nodes in that split second.
