### PR TITLE
Remove logging to syslog, keep stdout

### DIFF
--- a/src/SilverStripe/BlowGun/Command/BaseCommand.php
+++ b/src/SilverStripe/BlowGun/Command/BaseCommand.php
@@ -3,7 +3,6 @@ namespace SilverStripe\BlowGun\Command;
 
 use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\StreamHandler;
-use Monolog\Handler\SyslogHandler;
 use Monolog\Logger;
 use SilverStripe\BlowGun\Credentials\BlowGunCredentials;
 use Symfony\Component\Console\Command\Command;
@@ -51,13 +50,8 @@ abstract class BaseCommand extends Command {
 		$this->setCredentials($input);
 		$this->log = new Logger('blowgun');
 
-		$sysLogger = new SyslogHandler('blowgun');
-		$syslogFormatter = new LineFormatter("%level_name% - %message% %context%\n");
-		$sysLogger->setFormatter($syslogFormatter);
-		$this->log->pushHandler($sysLogger);
-
 		$streamLogger = new StreamHandler(STDOUT);
-		$streamFormatter = new LineFormatter("[%datetime%] %channel%.%level_name%: %message% %context%\n");
+		$streamFormatter = new LineFormatter("%level_name% - %message% %context%\n");
 		$streamLogger->setFormatter($streamFormatter);
 		$this->log->pushHandler($streamLogger );
 	}


### PR DESCRIPTION
The prefered way to log is by printing to STDOUT since blowgun should be running
as a service in systemctl that will by default log output from the blowgun

This will fix the problem that blowgun messages are duplicated in logs