### PR TITLE
log the scripts stdout/stderr into syslog in realtime

### DIFF
--- a/src/SilverStripe/BlowGun/Command/ListenCommand.php
+++ b/src/SilverStripe/BlowGun/Command/ListenCommand.php
@@ -165,15 +165,7 @@ class ListenCommand extends BaseCommand
 
         $this->logNotice(sprintf('Running job %s', $message->getType()), $message);
         $command = new Command($message, $this->scriptDir);
-        $status = $command->run();
-
-        foreach ($status->getErrors() as $error) {
-            $this->logError($error, $message);
-        }
-
-        foreach ($status->getNotices() as $notice) {
-            $this->logNotice($notice, $message);
-        }
+        $status = $command->run($this->log);
 
         if ($message->getRespondTo()) {
             $this->sendResponse($message, $status);


### PR DESCRIPTION
Before this change, blowgun waited until the command timed-out and then printed all the logs, but in a weird order and without timestamps.

This change makes blowgun log as quickly as possible into syslog so that we can debug timings and if a script is hanging for example.