### PR TITLE
Fixing setCredential passing incorrect for AWS SDK v3

### DIFF
--- a/src/SilverStripe/BlowGun/Service/SQSHandler.php
+++ b/src/SilverStripe/BlowGun/Service/SQSHandler.php
@@ -19,7 +19,7 @@ class SQSHandler
     const QUEUE_DEFAULT_VISIBILITY_TIMEOUT = 30; // 30 seconds
 
     /**
-     * @var CredentialsInterface
+     * @var callable|CredentialsInterface
      */
     protected static $credentials;
 
@@ -68,9 +68,9 @@ class SQSHandler
     }
 
     /**
-     * @param CredentialsInterface $credentials
+     * @param callable|CredentialsInterface $credentials
      */
-    public static function setCredentials(CredentialsInterface $credentials)
+    public static function setCredentials($credentials)
     {
         self::$credentials = $credentials;
     }


### PR DESCRIPTION
This can now either be passed as a resolved promise of a Credential
object, or the callable promise itself.