### PR TITLE
Use correct method for fetching result parameters

### DIFF
--- a/src/SilverStripe/BlowGun/Service/SQSHandler.php
+++ b/src/SilverStripe/BlowGun/Service/SQSHandler.php
@@ -145,11 +145,11 @@ class SQSHandler
                 ],
             ]
         );
-        if (!count($result['Messages'])) {
+        if (!$result->get('Messages') || !count($result->get('Messages'))) {
             return [];
         }
         $messages = [];
-        foreach ($result['Messages'] as $message) {
+        foreach ($result->get('Messages') as $message) {
             $tmp = new Message($queueName, $this);
 
             try {


### PR DESCRIPTION
Prevents `Warning: count(): Parameter must be an array or an object that implements Countable in phar:///usr/local/bin/blowgun/src/SilverStripe/BlowGun/Service/SQSHandler.php on line 148` warnings